### PR TITLE
updated greenestComp, annualThresholdImages, and annualMiningArea to …

### DIFF
--- a/MTM_Annual_Extent/code/annualMiningArea.py
+++ b/MTM_Annual_Extent/code/annualMiningArea.py
@@ -6,6 +6,7 @@ from google.cloud import storage
 
 from config import EE_SERVICE_ACCOUNT, EE_CREDENTIALS
 from mtm_utils.variables import (
+    PROCESSING_YEAR, 
     GCLOUD_BUCKET,
     GCLOUD_EE_GPC_DIR,
     GCLOUD_MASK_DIR,
@@ -27,7 +28,7 @@ INITIAL SET-UP
 # Defining the processing year, which is the current year minus 1 (THIS WILL NEED TO BE CHANGED WHEN SETTING UP THE
 # FINAL CRON, SINCE USCB DATA WILL BE UPDATED). IN FUTURE THIS WILL EQUAL CURRENT YEAR
 # processing_year = (datetime.date.today().year)
-processing_year = 2024
+processing_year = PROCESSING_YEAR
 
 # Our cleaning process relies on the use of dummy images, these are used to clean the years immediately before and after
 # the years for which we have Landsat scenes. We need images of value 0 so that the nullCleaning2 function will work.

--- a/MTM_Annual_Extent/code/annualThresholdImages.py
+++ b/MTM_Annual_Extent/code/annualThresholdImages.py
@@ -6,6 +6,7 @@ from google.cloud import storage
 
 from config import EE_SERVICE_ACCOUNT, EE_CREDENTIALS
 from mtm_utils.variables import (
+    PROCESSING_YEAR, 
     GCLOUD_BUCKET,
     GCLOUD_EE_GPC_DIR,
     GCLOUD_MASK_DIR,
@@ -14,8 +15,7 @@ from mtm_utils.variables import (
 )
 
 
-processing_year = datetime.date.today().year
-# processing_year = 2024
+processing_year = PROCESSING_YEAR
 
 # The ID of your GCS bucket
 storage_client = storage.Client()

--- a/MTM_Annual_Extent/code/greenestComp.py
+++ b/MTM_Annual_Extent/code/greenestComp.py
@@ -5,10 +5,10 @@ from ee import batch
 from google.cloud import storage
 
 from config import EE_SERVICE_ACCOUNT, EE_CREDENTIALS
-from mtm_utils.variables import GCLOUD_BUCKET, GCLOUD_EE_GPC_DIR
+from mtm_utils.variables import PROCESSING_YEAR, GCLOUD_BUCKET, GCLOUD_EE_GPC_DIR
 
 
-processing_year = datetime.date.today().year
+processing_year = PROCESSING_YEAR
 
 # The ID of your GCS bucket
 storage_client = storage.Client()


### PR DESCRIPTION
### Description

Minor updates so that greenestComp, annualThresholdImages, and annualMiningArea to use PROCESSING_YEAR as it is defined in mtm_utils/variables

### Changes
Set greenestComp, annualThresholdImages, and annualMiningArea to import PROCESSING_YEAR from mtm_utils/variables rather than defining separately in each script

### Reviewer Checklist

- [ ] Do the changes look good

### Associated tickets or issues

<!-- Does this address any specific JIRA tickets or GitHub Issues -->


### Created, updated, or replaced Files and/or tables

<!-- Are there any files or tables that are created or modified with this PR -->

- [ ]
